### PR TITLE
Se configuro docker-compose

### DIFF
--- a/build_appserv.sh
+++ b/build_appserv.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker build -t appserv .
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3'
+
+# docker-compose maneja una red interna donde mapea cada modulo a una url
+services:
+  appserv:
+    # el modulo product-service se construye a partir del Dockerfile y los archivos de product/
+    build: ./
+    volumes:
+      # product-service esta basado en la image python:3 la cual requiere que los source files se depositen en /usr/src/app
+      - ./:/usr/src/app
+    ports:
+      - 5000:5000
+      - 8000:8000
+    environment: 
+      - DATABASE_URL=appmongo
+
+  appmongo:
+    image: mongo:3.4
+    ports:
+      - 27017:27017

--- a/model/db_manager.py
+++ b/model/db_manager.py
@@ -1,5 +1,4 @@
 """ Facilita la operacion con la base de datos de mongo """
-
 import os
 from pymongo import MongoClient
 
@@ -46,7 +45,7 @@ def main():
 
     # Inserto un post y obtengo su id
     post_id = posts.insert_one(post).inserted_id
-    print(post_id)
+    print(post_id.__str__())
 
 if __name__ == '__main__':
     main()

--- a/prompt_mongo.sh
+++ b/prompt_mongo.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker run -it --link some-mongo:mongo --rm mongo:3.4 sh -c 'exec mongo "$MONGO_PORT_27017_TCP_ADDR:$MONGO_PORT_27017_TCP_PORT/test"'
+

--- a/start_appserv_mongo.sh
+++ b/start_appserv_mongo.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker run --name appserv --link some-mongo:mongo --rm -e MONGODB_URI=mongo -p 5000:5000 -p 8000:8000 appserv
+

--- a/start_mongo.sh
+++ b/start_mongo.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker run --name some-mongo -d mongo:3.4
+


### PR DESCRIPTION
Se agregaron las configuraciones de docker-compose de forma tal que se
pueda iniciar el server mediante "docker-compose up" . De esta manera se
levantaran dos contenedores : uno del appserver y uno de mongo. El
contenedor del appserver podra hablar con el de mongo y correr queries.